### PR TITLE
feat: arbitrary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 description = "a small crate to work with NEAR token values ergonomically and efficiently (NEAR Protocol)"
 
 [dependencies]
+arbitrary = { version = "1", features = ["derive"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 borsh = { version = "1", features = ["derive"], optional = true }
 schemars-v1 = { version = "1.0.3", optional = true, package = "schemars" }
@@ -24,9 +25,10 @@ serde_json = { version = "1" }
 
 [features]
 abi = ["borsh/unstable__schema", "schemars"]
+arbitrary = ["dep:arbitrary"]
 serde = ["dep:serde"]
 interactive-clap = ["dep:interactive-clap"]
 borsh = ["dep:borsh"]
 schemars = ["schemars-v0_8"]
 schemars-v1 = ["dep:schemars-v1"]
-schemars-v0_8 = ["dep:schemars-v0_8"] 
+schemars-v0_8 = ["dep:schemars-v0_8"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod trait_impls;
 pub use self::error::NearTokenError;
 pub use self::utils::DecimalNumberParsingError;
 
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
 #[cfg_attr(
     feature = "borsh",


### PR DESCRIPTION
This PR adds `arbitrary` feature. When this feature enabled, `NearToken` derives `Arbitrary` trait, which can be useful in fuzzing tests