### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/near/near-token-rs/compare/v0.3.3...v0.3.4) - 2026-02-12
+
+### Added
+
+- Added `arbitrary` feature flag ([#22](https://github.com/near/near-token-rs/pull/22))
+
+### Other
+
+- Add CODEOWNERS file for repository ownership
+- upgrade to Rust edition 2024 ([#21](https://github.com/near/near-token-rs/pull/21))
+
 ## [0.3.3](https://github.com/near/near-token-rs/compare/v0.3.2...v0.3.3) - 2025-11-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-token"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 authors = [
     "Serhieiev Ivan <serhieievivan6@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-token`: 0.3.3 -> 0.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.4](https://github.com/near/near-token-rs/compare/v0.3.3...v0.3.4) - 2026-02-12

### Added

- Added `arbitrary` feature flag ([#22](https://github.com/near/near-token-rs/pull/22))

### Other

- Add CODEOWNERS file for repository ownership
- upgrade to Rust edition 2024 ([#21](https://github.com/near/near-token-rs/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).