### PR TITLE
ci: fix MSRV job by aligning toolchain with Cargo.toml rust-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install minimal supported Rust version
-      uses: dtolnay/rust-toolchain@1.68
-
-    - name: downgrade `indexmap` crate to support older Rust toolchain
-      run: |
-        cargo update -p indexmap --precise 2.11.4
+      uses: dtolnay/rust-toolchain@1.85.0
 
     - name: Run cargo test
       run: cargo test --verbose


### PR DESCRIPTION
## Summary
- The MSRV job has been failing on `main` since v0.3.4: it pinned `indexmap` to 2.11.4 to support an older Rust toolchain, but `toml_edit v0.25.11` (transitive via `borsh-derive` -> `proc-macro-crate`) now requires `indexmap >= 2.13.0`, so the precise pin can't be satisfied.
- After the edition 2024 upgrade (#21) the crate's MSRV is 1.85.0, which makes the indexmap downgrade unnecessary anyway.
- Bumps the MSRV CI toolchain from `1.68` to `1.85.0` to match `Cargo.toml`'s `rust-version`, and drops the stale `cargo update -p indexmap --precise 2.11.4` step.

This unblocks `release-plz` so we can ship the next release.

## Test plan
- [x] `cargo test --verbose` passes locally on 1.85.0
- [x] CI `test-msrv` job goes green
- [x] CI `test-all-features`, `clippy`, `cargo-fmt` jobs stay green